### PR TITLE
Added require dev to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,10 @@
         "illuminate/support": "~4.1",
         "nesbot/carbon": "~1.0"
     },
+    "require-dev": {
+        "stripe/stripe-php": "~1.9",
+        "braintree/braintree_php" : "2.33.0"
+    },
     "suggest": {
         "stripe/stripe-php": "Add the Stripe gateway SDK.",
         "braintree/braintree_php": "Add the Braintree gateway SDK."


### PR DESCRIPTION
This is really nice when doing development and you don't want to have to load the composer packages in your main project (outside of the Laravel workspace).

I don't know what version Braintree's PHP SDK was developed against so if you could add that after merging I think it would be great.