### PR TITLE
Laravel Billiing Use class Issue

### DIFF
--- a/src/Mmanos/Billing/CustomerBillableTrait/Subscriptions.php
+++ b/src/Mmanos/Billing/CustomerBillableTrait/Subscriptions.php
@@ -1,6 +1,5 @@
 <?php namespace Mmanos\Billing\CustomerBillableTrait;
 
-use Mmanos\Billing\Facades\Billing;
 use Illuminate\Support\Arr;
 
 class Subscriptions


### PR DESCRIPTION
Removed Billing Facade use reference in Subscriptions.

Code Reference: 
https://github.com/mmanos/laravel-billing/commit/8a5e58dba81a9872c7d61bf580f152a763a568b9